### PR TITLE
Fix display glitches

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HeaderREPLs"
 uuid = "0c95fe84-97b8-11e8-34fd-7ba5e722bbed"
 authors = ["Tim Holy <tim.holy@gmail.com>"]
-version = "0.1.0"
+version = "0.2.0"
 
 [deps]
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"

--- a/README.md
+++ b/README.md
@@ -12,17 +12,22 @@ information above the prompt.
 To demonstrate, here we build a `CountingHeader` type and show how the header is printed:
 
 ```julia
-mutable struct CountingHeader <: AbstractHeader
-    n::Int
+mutable struct CountingHeader <: AbstractHeader    # note must be mutable and contain nlines field
+    n::Int            # internal data needed by the header
+    nlines::Int       # the number of lines needed for display---update this in print_header
 end
 
 function HeaderREPLs.print_header(io::IO, header::CountingHeader)
-    if header.n > 0
-        printstyled(io, "Header:\n"; color=:light_magenta)
-        for i = 1:header.n
-            printstyled(io, "  ", i, '\n'; color=:light_blue)
+    if header.nlines == 0
+        if header.n > 0
+            printstyled(io, "Header:\n"; color=:light_magenta)
+            for i = 1:header.n
+                printstyled(io, "  ", i, '\n'; color=:light_blue)
+            end
         end
+        header.nlines = nlines(header.n)
     end
+    return nothing
 end
 ```
 
@@ -53,6 +58,12 @@ In this demo, "count" mode is non-sticky, so it reverts back to the `julia>` pro
 In theory at least, "count" mode works as you'd expect when you traverse the
 history: when you get to a "count" line it shows the (current) header.
 
+## Utilities
+
+The package exports a few utilities that may make it easier to define custom REPL modes.
+Aside from key-binding initialization utilities (see the source for details),
+perhaps the two most useful are `find_prompt` and `count_display_lines`.
+Use `?` for more information.
 
 ## Notes
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,17 +5,23 @@ using REPL.LineEdit: transition, state
 
 mutable struct CountingHeader <: AbstractHeader
     n::Int
+    nlines::Int
 end
+nlines(n) = n == 0 ? 0 : n+1
+CountingHeader(n::Integer) = CountingHeader(n, nlines(n))
 
 function HeaderREPLs.print_header(io::IO, header::CountingHeader)
-    if header.n > 0
-        printstyled(io, "Header:\n"; color=:light_magenta)
-        for i = 1:header.n
-            printstyled(io, "  ", i, '\n'; color=:light_blue)
+    if header.nlines == 0
+        if header.n > 0
+            printstyled(io, "Header:\n"; color=:light_magenta)
+            for i = 1:header.n
+                printstyled(io, "  ", i, '\n'; color=:light_blue)
+            end
         end
+        header.nlines = nlines(header.n)
     end
+    return nothing
 end
-HeaderREPLs.nlines(terminal, header::CountingHeader) = header.n == 0 ? 0 : header.n+1
 
 function HeaderREPLs.setup_prompt(repl::HeaderREPL{CountingHeader}, hascolor::Bool)
     julia_prompt = find_prompt(repl.interface, "julia")
@@ -52,7 +58,7 @@ end
 function modify(s, repl, diff)
     clear_io(state(s), repl)
     repl.header.n = max(0, repl.header.n + diff)
-    refresh_header(s, repl; clearheader=false)
+    refresh_header(s, repl)
 end
 
 @noinline increment(s, repl) = modify(s, repl, +1)


### PR DESCRIPTION
By allowing print_header to interact with HeaderREPLs through an
`nlines` field in the header struct, it becomes much easier to keep
track of which lines need to be drawn or erased.

Also adds `count_display_lines` to account for word-wrap in displays.

It is likely that this will temporarily break Rebugger, but a new version is on its way shortly that
exploits this.